### PR TITLE
feat: complete atomic rollback engine and fix vanguard audit bugs

### DIFF
--- a/src/sentinel/cli.py
+++ b/src/sentinel/cli.py
@@ -1,6 +1,8 @@
 import typer
 from rich.console import Console 
 import sys
+import os
+import time
 import select
 
 from sentinel.core.hooks import install
@@ -10,9 +12,23 @@ from sentinel.vanguard.boot import analyze_boot_health
 from sentinel.vanguard.system import run_preflight_checks, assess_blast_radius, parse_and_sanitize_packages
 from sentinel.recovery.snapshot import trigger_snapshot
 from sentinel.intelligence.diagnose import run_diagnostics
+from sentinel.recovery.undo import get_last_snapshot, verify_snapshot, execute_rollback
 
 console = Console()
 app = typer.Typer(help="Sentinel Linux: Predict, Protect, Recover")
+
+def _format_relative_time(timestamp: float) -> str:
+    """
+    Helper function to convert UNIX time to human readable format.
+    """
+    diff = time.time() - timestamp
+    if diff < 60:
+        return "Just now"
+    elif diff < 3600:
+        return f"{int(diff // 60)} minutes ago"
+    elif diff < 86400:
+        return f"{int(diff // 3600)} hours ago" 
+    return f"{int(diff // 86400)} days ago"
 
 @app.command()
 def predict():
@@ -48,7 +64,7 @@ def predict():
             logger.warning(f"High-Risk Update Detected ({risk_category}). Triggering snapshot.")
             console.print(f"\n[bold cyan] High-Risk Update Detected: [white]{risk_category}[/white][/bold cyan]")
             console.print("  [cyan]Engaging Recovery Guardrails...[/cyan]")
-            trigger_snapshot(input_data)
+            trigger_snapshot(input_data, risk_category)
         else:
             logger.info("No high-risk packages detected in transaction.")
 
@@ -77,9 +93,64 @@ def undo():
     """
     Instantly revert the system to the last Sentinel-created snapshot.
     """
-    logger.info("User requested undo. Feature under construction.")
-    console.print("\n[bold yellow]🚧 The 'undo' engine is currently under construction.[/bold yellow]")
-    console.print("[white]Soon, this will automatically restore your last Timeshift/Snapper backup.[/white]\n")
+    logger.info("User requested atomic rollback (undo)")
+
+    # Root check
+    if os.geteuid() != 0:
+        logger.error("Undo failed: Root privileges required.")
+        console.print("\n[bold red]Error: Restoring a root filesystem requires root privileges.[/bold red]")
+        console.print("Try running: [bold yellow]sudo sentinel undo[/bold yellow]\n")
+        sys.exit(1)
+
+    console.print("\n[bold cyan]~~~ Sentinel Recovery Engine ~~~[/bold cyan]")
+
+    # State check
+    state = get_last_snapshot()
+    if not state:
+        logger.warning("Undo aborted: No snapshot history found.")
+        console.print("[yellow]No recent Sentinel snapshots found on this system.[/yellow]")
+        console.print("[dim white]If you recently installed Sentinel, a snapshot will be created automatically on your next high-risk update.[/dim white]\n")
+        sys.exit(0)
+
+    # Verification check
+    console.print("[dim]Verifying snapshot integrity...[/dim]")
+    if not verify_snapshot(state):
+        logger.error(f"Undo aborted: Snapshot {state.get('snapshot_name')} no longer exists.")
+        console.print(f"[bold red]Error: The snapshot '{state.get('snapshot_name')}' could not be found.[/bold red]")
+        console.print("[white]It may have been manually deleted or cleared by your backup provider's cleanup rules.[/white]\n")
+        sys.exit(1)
+
+    provider = str(state.get("provider", "unknown")).capitalize()
+    snap_name = state.get("snapshot_name", "Unknown")
+    reason = state.get("trigger_reason", "Unknown trigger")
+    rel_time = _format_relative_time(state.get("created_at", time.time()))
+
+    console.print(f"  [bold white]Provider:[/bold white]       {provider}")
+    console.print(f"  [bold white]Snapshot Name:[/bold white]  [green]{snap_name}[/green]")
+    console.print(f"  [bold white]Created:[/bold white]        {rel_time}")
+    console.print(f"  [bold white]Trigger Reason:[/bold white] {reason}\n")
+    
+    console.print("[bold red]!!!!WARNING: This will overwrite your root filesystem and immediately reboot your machine.[/bold red]")
+
+    confirm = typer.confirm("Proceed with system rollback?")
+
+    if not confirm:
+        logger.info("User aborted rollback at confirmation prompt.")
+        console.print("[yellow]Rollback aborted by user.[/yellow]\n")
+        sys.exit(0)
+
+    # If confirmed, continue with the rollback
+    console.print(f"\n[bold cyan]Initiating {provider} restoration...[/bold cyan]")
+    success = execute_rollback(state)
+
+    if success:
+        if provider.lower() == "timeshift":
+            console.print("[bold green]Rollback complete. Your system will reboot shortly.[/bold green]")
+        else:
+            console.print("[bold green]Rollback complete. Please reboot manually: [yellow]sudo reboot[/yellow][/bold green]")
+    else:
+        console.print("[bold red]Rollback failed. Check /var/log/sentinel.log for details.[/bold red]\n")
+        sys.exit(1)
 
 @app.command()
 def heal():

--- a/src/sentinel/recovery/snapshot.py
+++ b/src/sentinel/recovery/snapshot.py
@@ -3,6 +3,8 @@ import shutil
 import re
 import time
 import os
+import json
+from pathlib import Path
 from rich.console import Console
 from sentinel.core.logger import logger
 
@@ -10,7 +12,8 @@ console = Console()
 
 COOLDOWN_SECONDS = 600
 MIN_FREE_GB = 5
-STATE_FILE = "/tmp/sentinel_last_snapshot.txt"
+STATE_DIR = Path("/var/lib/sentinel")
+STATE_FILE = STATE_DIR / "last_snapshot.json"
 
 def check_disk_space() -> bool:
     """Ensures the root partition has enough free space for a snapshot."""
@@ -23,47 +26,66 @@ def check_disk_space() -> bool:
         return False
     return True
 
+def get_last_snapshot_state() -> dict:
+    """Safely reads the snapshot state JSON if it exists."""
+    if not STATE_FILE.exists():
+        return {}
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception as e:
+        logger.error(f"Failed to read snapshot state: {e}")
+        return {}
+
 def is_in_cooldown() -> bool:
-    """Checks if a snapshot was taken recently to prevent snapshot spam."""
-    if not os.path.exists(STATE_FILE):
+    """Checks if a snapshot was taken recently using the JSON state."""
+    state = get_last_snapshot_state()
+    if not state or "created_at" not in state:
         return False
     
-    try:
-        with open(STATE_FILE, "r") as f:
-            last_snap_time = float(f.read().strip())
-        
-        elapsed = time.time() - last_snap_time
-        if elapsed < COOLDOWN_SECONDS:
-            mins_left = int((COOLDOWN_SECONDS - elapsed) / 60)
-            logger.info(f"Snapshot skipped due to cooldown. ({mins_left}m remaining)")
-            console.print(f"  [cyan]Recent snapshot detected. Skipping to save time (Cooldown: ~{mins_left}m left).[/cyan]")
-            return True
-    except (ValueError, IOError):
-        pass
-
+    elapsed = time.time() - state["created_at"]
+    if elapsed < COOLDOWN_SECONDS:
+        mins_left = int((COOLDOWN_SECONDS - elapsed) / 60)
+        logger.info(f"Snapshot skipped due to cooldown. ({mins_left}m remaining)")
+        console.print(f"  [cyan]Recent snapshot detected. Skipping to save time (Cooldown: {mins_left}m left).[/cyan]")
+        return True
     return False
 
-def mark_snapshot_time():
-    """Records the timestamp of a successful snapshot."""
+def save_snapshot_state(provider: str, snap_id_or_name: str, reason: str):
+    """
+    Persists the snapshot metadata to disk.
+    """
     try:
-        with open(STATE_FILE, "w") as f:
-            f.write(str(time.time()))
-    except IOError:
-        logger.debug("Failed to write snapshot cooldown state.")
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+        state = {
+            "provider": provider,
+            "snapshot_name": snap_id_or_name,
+            "created_at": time.time(),
+            "trigger_reason": reason 
+        }
+
+        STATE_FILE.write_text(json.dumps(state, indent=4))
+
+        if os.geteuid() == 0:
+            os.chmod(STATE_FILE, 0o600)
+
+        logger.debug(f"Saved snapshot state to {STATE_FILE}")
+    except Exception as e:
+        logger.error(f"Failed to save snapshot state: {e}")
 
 def get_snapshot_provider():
     """
     Detects if a supported system snapshot tool is installed.
     Prioritizes Snapper (BTRFS native), falls back to Timeshift.
     """
-
     if shutil.which("snapper"):
         return "snapper"
     if shutil.which("timeshift"):
         return "timeshift"
     return None
 
-def trigger_snapshot(package_data: str):
+
+def trigger_snapshot(package_data: str, trigger_reason: str = "Unknown Safety Trigger") -> bool:
     """
     Triggers an automated system snapshot using the available provider.
     Includes disk space guards, cooldown timers, and timeout protection.
@@ -87,7 +109,6 @@ def trigger_snapshot(package_data: str):
     comment = f"Sentinel Pre-Update: {preview}..."
     logger.info(f"Triggering {provider} snapshot. Target: {comment}")
 
-    # We use console.status to show a loading spinner (Timeshift takes time, Snapper is instant)
     with console.status (f"[bold cyan]Creating {provider.capitalize()} Snapshot (Do not close terminal (Max Wait: 120s))...[/bold cyan]", spinner="dots"):
         try:
             if provider == "snapper":
@@ -103,9 +124,9 @@ def trigger_snapshot(package_data: str):
                 
                 logger.info(f"Snapper snapshot created successfully. ID: {snap_id}")
                 console.print(f"  [bold green]Snapper Snapshot Created:[/bold green] ID [bold white]{snap_id}[/bold white]")
-                console.print(f"    [white]↳ To undo this update later, run:[/white] [bold yellow]sudo snapper rollback {snap_id}[/bold yellow]")
+                console.print(f"    [white]↳ To undo this update later, run:[/white] [bold yellow]sudo sentinel undo[/bold yellow]")
                 
-                mark_snapshot_time()
+                save_snapshot_state(provider, snap_id, trigger_reason)
                 return True
 
             elif provider == "timeshift":
@@ -123,9 +144,9 @@ def trigger_snapshot(package_data: str):
                 
                 logger.info(f"Timeshift snapshot created successfully. Name: {snap_name}")
                 console.print(f"  [bold green]Timeshift Snapshot Created:[/bold green] [bold white]{snap_name}[/bold white]")
-                console.print(f"    [white]↳ To undo this update later, run:[/white] [bold yellow]sudo timeshift --restore --snapshot '{snap_name}'[/bold yellow]")
+                console.print(f"    [white]↳ To undo this update later, run:[/white] [bold yellow]sudo sentinel undo[/bold yellow]")
                 
-                mark_snapshot_time()
+                save_snapshot_state(provider, snap_name, trigger_reason)
                 return True
             
         except subprocess.TimeoutExpired as e:

--- a/src/sentinel/recovery/undo.py
+++ b/src/sentinel/recovery/undo.py
@@ -1,0 +1,75 @@
+import subprocess
+import json
+from pathlib import Path
+from sentinel.core.logger import logger
+
+STATE_FILE = Path("/var/lib/sentinel/last_snapshot.json")
+
+def get_last_snapshot() -> dict | None:
+    """Reads the JSON state file to retrieve the last snapshot data."""
+    if not STATE_FILE.exists():
+        return None
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception as e:
+        logger.error(f"Failed to read undo state: {e}")
+        return None
+    
+def verify_snapshot(state: dict) -> bool:
+    """
+    Asks the backup provider if the snapshot still exists on the disk.
+    Prevents crashing if the user manually deleted the snapshot.
+    """
+    provider = state.get("provider")
+    snap_target = str(state.get("snapshot_name", ""))
+
+    if not provider or not snap_target:
+        return False
+    
+    try:
+        if provider == "snapper":
+            res = subprocess.run(
+                ["snapper", "list"],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            return snap_target in res.stdout
+        elif provider == "timeshift":
+            res = subprocess.run(
+                ["timeshift", "--list"],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            return snap_target in res.stdout
+    except Exception as e:
+        logger.error(f"Snapshot verification failed for {provider}: {e}")
+        return False
+
+    return False
+
+def execute_rollback(state: dict) -> bool:
+    """Triggers the rollback command."""
+    provider = state.get("provider")
+    snap_target = str(state.get("snapshot_name", ""))
+
+    try:
+        if provider == "snapper":
+            logger.info(f"Executing Snapper rollback to ID {snap_target}")
+            subprocess.run(["snapper", "rollback", snap_target], check=True)
+            return True
+        
+        elif provider == "timeshift":
+            logger.info(f"Executing Timeshift rollback to {snap_target}")
+            subprocess.run([
+                "timeshift", "--restore", "--snapshot", snap_target, 
+                "--scripted", "--yes"
+            ], check=True)
+            return True
+        
+    except subprocess.CalledProcessError as e:
+        logger.error(f"{provider.capitalize()} rollback command failed: {e}")
+        return False
+    
+    return False

--- a/src/sentinel/vanguard/boot.py
+++ b/src/sentinel/vanguard/boot.py
@@ -33,7 +33,12 @@ def count_installed_kernels() -> int:
         kernels = [f for f in os.listdir("/boot") if f.startswith("vmlinuz")]
         count = len(kernels)
         logger.debug(f"Found {count} installed kernels in /boot.")
+        return count
     except FileNotFoundError:
+        logger.error("/boot directory not found during kernel count.")
+        return 0
+    except Exception as e:
+        logger.error(f"Unexpected error counting kernels: {e}")
         return 0
 
 def analyze_boot_health(safe_package_list: list[str]) -> bool:

--- a/src/sentinel/vanguard/security.py
+++ b/src/sentinel/vanguard/security.py
@@ -25,7 +25,7 @@ def get_secure_boot_status() -> bool:
         set_cached_state({"sb_enabled": is_enabled})
         logger.debug(f"Secure Boot status verified via mokutil: {is_enabled}")
         return is_enabled
-    except Exception:
+    except Exception as e:
         # If mokutil isn't installed or fails, assume permissive mode
         logger.warning(f"Failed to check Secure Boot status (assuming permissive): {e}")
         return False
@@ -43,7 +43,7 @@ def get_dkms_modules() -> list[str]:
         modules = res.stdout.strip().splitlines()
         logger.debug(f"Found {len(modules)} active DKMS modules.")
         return modules
-    except Exception:
+    except Exception as e:
         logger.warning(f"Failed to fetch DKMS status: {e}")
         return []
     
@@ -66,7 +66,6 @@ def analyze_security_risk(safe_package_list: list[str]) -> bool:
     if not (kernel_changing or dkms_changing or shim_changing):
         return True
 
-    logger.warning(f"Failed to fetch DKMS status: {e}")
     console.print("[bold blue]Sentinel Security & Driver Audit...[/bold blue]")
     
     sb_active = get_secure_boot_status()


### PR DESCRIPTION
The atomic rollback, creates a json file to save the last snapshot info.
Rather than showing the whole command for the user to use for different providers, the code automatically checks for the provider and then runs the corresponding "snapper" or "timeshift" for rolling back the snapshot, if the user runs "sentinel undo".
