### PR TITLE
fix: harden state directory permissions

### DIFF
--- a/src/sentinel/recovery/snapshot.py
+++ b/src/sentinel/recovery/snapshot.py
@@ -56,6 +56,7 @@ def save_snapshot_state(provider: str, snap_id_or_name: str, reason: str):
     """
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
+        STATE_DIR.chmod(0o700)
 
         state = {
             "provider": provider,


### PR DESCRIPTION
- Enforces 700 (root-only) permissions on /var/lib/sentinel.
- Prevents unprivileged users from reading snapshot metadata.