### PR TITLE
fix: resolve phantom OTA loop and dynamic wave layout rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prescient-linux"
-version = "0.11.9"
+version = "0.12.0"
 description = "Predict. Protect. Recover. An intelligent CLI stability layer for Linux."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/prescient/core/update_checker.py
+++ b/src/prescient/core/update_checker.py
@@ -1,5 +1,6 @@
 import urllib.request
 import re
+from pathlib import Path
 from importlib.metadata import version, PackageNotFoundError
 from prescient.core.logger import logger
 
@@ -8,8 +9,26 @@ def get_local_version() -> str:
     Fetches the currently installed version from package metadata.
     """
     try:
-        return version("prescient-linux")
+        # Looking in pyproject.toml
+        pyproject_path = Path(__file__).resolve().parent.parent.parent.parent / "pyproject.toml"
+        if pyproject_path.exists():
+            content = pyproject_path.read_text(encoding="utf-8")
+            
+            match = re.search(r'^\s*version\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+            if match:
+                local_ver = match.group(1).strip()
+                logger.debug(f"Local version '{local_ver}' loaded from pyproject.toml")
+                return local_ver
+    except Exception as e:
+        logger.debug(f"Failed to read local pyproject.toml: {e}")
+        
+    try:
+        # Fallbacking to standard package metadata
+        fallback_ver = version("prescient-linux")
+        logger.debug(f"Local version '{fallback_ver}' loaded from package metadata fallback")
+        return fallback_ver
     except PackageNotFoundError:
+        logger.warning("Local version could not be determined (Package not found).")
         return "unknown"
 
 def check_for_updates() -> bool:
@@ -19,6 +38,7 @@ def check_for_updates() -> bool:
     """
     local_version_raw = get_local_version()
     if local_version_raw == "unknown":
+        logger.debug("OTA update check aborted: Local version is unknown.")
         return False
     
     local_version = local_version_raw.lstrip("v").strip()
@@ -35,8 +55,10 @@ def check_for_updates() -> bool:
                 remote_version = match.group(1).lstrip("v").strip()
                 if remote_version != local_version:
                     return True
+            else:
+                logger.warning("OTA Check failed: Could not parse version from remote pyproject.toml")
     
     except Exception as e:
-        logger.debug(f"Update check skipped or failed: {e}")
+        logger.warning(f"OTA update check skipped or failed (offline/timeout): {e}")
 
     return False

--- a/src/prescient/tui/app.py
+++ b/src/prescient/tui/app.py
@@ -78,7 +78,7 @@ class MainDashboard(Container):
             
             with Vertical(id="right-pane"):
                 with Horizontal(id="update-banner"):
-                    yield Static("System is up to date. No new OTA releases.", id="update-text")
+                    yield Static("", id="update-text")
                     yield DuneWave(id="main-wave")
                 
                 with Vertical(id="content-area"):
@@ -140,8 +140,8 @@ class PrescientTUI(App):
 
     #right-pane { width: 1fr; height: 100%; }
     #update-banner { height: 8; border-bottom: solid $primary-darken-2; padding: 0 2; align: center middle; }
-    #update-text { width: 1fr; height: 8; content-align: center middle; text-align: center; color: $success; text-style: bold; }
-    #main-wave { width: 1fr; height: 8; dock: right;}
+    #update-text { width: 1fr; height: 8; content-align: center middle; text-align: center; color: $success; text-style: bold; display: none; }
+    #main-wave { width: 1fr; height: 8; }
 
     #content-area { height: 1fr; padding: 1 3; }
     #doc-viewer { height: 1fr; overflow-y: auto; }
@@ -174,9 +174,11 @@ class PrescientTUI(App):
     
     def _show_update_banner(self) -> None:
         try:
-            self.query_one("#update-text", Static).update(
+            banner_text = self.query_one("#update-text", Static)
+            banner_text.update(
                 "[bold #fabd2f]New Prescient version available![/bold #fabd2f]\nPress 'u' to jump to 'update'."
             )
+            banner_text.display = True
         except Exception as e:
             logger.error(f"TUI failed to display update banner: {e}")
     


### PR DESCRIPTION
- Bypassed pip metadata caching by explicitly parsing local pyproject.toml for version checks. 
- Added granular debug telemetry to the update checker for easier diagnostics. 
- Implemented Textual CSS display toggling in the TUI banner so the DuneWave defaults to 100% width and dynamically flexes to a 50/50 split only when an update is actively detected.