### PR TITLE
enhancement: implement 24-hour OTA update caching to prevent network latency 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prescient-linux"
-version = "0.12.7"
+version = "0.12.8"
 description = "Predict. Protect. Recover. An intelligent CLI stability layer for Linux."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/prescient/cli.py
+++ b/src/prescient/cli.py
@@ -44,7 +44,7 @@ def main(ctx: typer.Context):
     Global hook that runs before commands to check for OTA updates.
     """
     if ctx.invoked_subcommand not in ["predict", "update", "uninstall", "install-hooks", "tui"]:
-        if check_for_updates():
+        if check_for_updates(force_network=True):
             console.print("[bold yellow]!A new version of Prescient is available![/bold yellow]")
             console.print("[dim]Run `sudo prescient update` to install it securely.[/dim]\n")
 
@@ -127,6 +127,9 @@ def predict():
 
     logger.info("Audit complete. Proceeding with installation.")    
     console.print("\n[bold green]Prescient Audit Complete. Proceeding with transaction...[/bold green]")
+
+    if CONFIG.get("update", {}).get("is_available", False):
+        console.print("[dim]ℹ A new Prescient update is available. Run 'sudo prescient update'[/dim]")
 
 @app.command()
 def diagnose(
@@ -274,7 +277,7 @@ def update(
 
     # Checking for an actual update before pulling
     if not force:
-        if not check_for_updates():
+        if not check_for_updates(force_network=True):
             console.print("[bold green]System is already up to date. No new OTA releases found.[/bold green]")
             console.print("[dim](Use 'sudo prescient update --force' to reinstall anyway)[/dim]\n")
             logger.info("OTA update skipped: System is already at the latest version.")

--- a/src/prescient/config.py
+++ b/src/prescient/config.py
@@ -115,4 +115,40 @@ def save_auto_snapshot_config(enabled: bool) -> bool:
         logger.error(f"Failed to save snapshot config: {e}")
         return False
 
+def save_update_cache(last_checked: float, is_available: bool) -> bool:
+    """
+    Saves the timestamp and result of the last OTA update check.
+    """
+    path = get_active_config_path()
+
+    if not path:
+        path = PROJECT_ROOT / "prescient.toml"
+        if not path.exists():
+            path.touch()
+    
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+            doc = tomlkit.parse(content) if content else tomlkit.document()
+
+        # Adding update table in toml file
+        if "update" not in doc:
+            doc.add("update", tomlkit.table())
+        
+        doc["update"]["last_checked"] = last_checked
+        doc["update"]["is_available"] = is_available
+
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(tomlkit.dumps(doc))
+        
+        if os.geteuid() == 0:
+            os.chmod(path, 0o644)
+        
+        reload_config()
+        return True
+    except Exception as e:
+        logger.error(f"Failed to save update cache: {e}")
+        return False
+
+
 reload_config()

--- a/src/prescient/core/update_checker.py
+++ b/src/prescient/core/update_checker.py
@@ -1,8 +1,10 @@
+import time
 import urllib.request
 import re
 from pathlib import Path
 from importlib.metadata import version, PackageNotFoundError
 from prescient.core.logger import logger
+from prescient.config import CONFIG, save_update_cache
 
 def get_local_version() -> str:
     """
@@ -31,34 +33,50 @@ def get_local_version() -> str:
         logger.warning("Local version could not be determined (Package not found).")
         return "unknown"
 
-def check_for_updates() -> bool:
+def check_for_updates(force_network: bool = False) -> bool:
     """
     Pings the main GitHub repo's pyproject.toml to see if the remote version is newer.
-    Fails silently and instantly if offline.
+    Uses a 24-hour cache to prevent network spam during routine package installations.
     """
+    # Cache check
+    if not force_network:
+        update_data = CONFIG.get("update", {})
+        last_checked = update_data.get("last_checked", 0.0)
+        is_available = update_data.get("is_available", False)
+
+        if (time.time() - last_checked) < 86400:
+            logger.debug("OTA check: Using cached result (checked < 24h ago).")
+            return is_available
+    
+    # Network Update check
     local_version_raw = get_local_version()
     if local_version_raw == "unknown":
         logger.debug("OTA update check aborted: Local version is unknown.")
         return False
     
     local_version = local_version_raw.lstrip("v").strip()
-    
+    update_found = False
+
     try:
         url = "https://raw.githubusercontent.com/GurKalra/prescient-linux/main/pyproject.toml"
         req = urllib.request.Request(url)
 
-        with urllib.request.urlopen(req, timeout=5.0) as response:
+        with urllib.request.urlopen(req, timeout=15.0) as response:
             content = response.read().decode("utf-8")
-            
+
             match = re.search(r'^\s*version\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
             if match:
                 remote_version = match.group(1).lstrip("v").strip()
                 if remote_version != local_version:
-                    return True
+                    update_found = True
             else:
                 logger.warning("OTA Check failed: Could not parse version from remote pyproject.toml")
-    
+
     except Exception as e:
         logger.warning(f"OTA update check skipped or failed (offline/timeout): {e}")
+    
+    # Saving to cache
+    logger.debug(f"OTA network check complete. Update found: {update_found}. Saving cache.")
+    save_update_cache(time.time(), update_found)
 
-    return False
+    return update_found

--- a/src/prescient/tui/app.py
+++ b/src/prescient/tui/app.py
@@ -180,7 +180,7 @@ class PrescientTUI(App):
     
     @work(thread=True)
     def run_update_check(self) -> None:
-        if check_for_updates():
+        if check_for_updates(force_network=True):
             logger.info("TUI update check: new version available.")
             self.call_from_thread(self._show_update_banner)
     
@@ -188,7 +188,7 @@ class PrescientTUI(App):
         try:
             banner_text = self.query_one("#update-text", Static)
             banner_text.update(
-                "[bold #fabd2f]New Prescient version available![/bold #fabd2f]\nPress 'u' to jump to 'update'."
+                "[bold #fabd2f]New Prescient version available![/bold #fabd2f]\nPress 'u' to jump to 'update' and run the command."
             )
             banner_text.display = True
         except Exception as e:


### PR DESCRIPTION
- Built a stateful caching engine in update_checker.py and config.py to store update availability. 
- The background predict engine now reads this 0ms-latency cache to notify CLI users of updates without halting package manager transactions. 
- Interactive commands (update, tui, diagnose) explicitly bypass the cache using force_network=True to guarantee fresh data.